### PR TITLE
FIX: Issue #1 - Invalid parent shown when true parent locked

### DIFF
--- a/app/helpers/users_helper_patch.rb
+++ b/app/helpers/users_helper_patch.rb
@@ -25,7 +25,7 @@ module UsersHelperPatch
 		end
 
 		def valid_user_parents
-			User.all.select(&:active?) - [@user] - @user.descendants
+			(User.all.select(&:active?) + User.where("id=?",@user.parent_id) - [@user] - @user.descendants).uniq
 		end
 	end
 end

--- a/app/helpers/users_helper_patch.rb
+++ b/app/helpers/users_helper_patch.rb
@@ -2,10 +2,7 @@ module UsersHelperPatch
 	def self.included(base)
 		base.send(:include, InstanceMethods)
 
-		# Wrap the methods we are extending
-		base.alias_method_chain :users_status_options_for_select, :parent_id
-
-		# Exectue this code at the class level (not instance level)
+		# Execute this code at the class level (not instance level)
 		base.class_eval do
 			unloadable # Send unloadable so it will not be unloaded in development
 

--- a/app/views/redmine_my_users/index.html.erb
+++ b/app/views/redmine_my_users/index.html.erb
@@ -6,7 +6,7 @@
 
 		<label for='status'><%= l(:field_status) %>:</label>
 		<%= select_tag 'status',
-			users_status_options_for_select(@status),
+			users_status_options_for_select_with_parent_id(@status),
 			:class => "small",
 			:onchange => "this.form.submit(); return false;"  %>
 
@@ -54,4 +54,3 @@
 <p class="pagination"><%= pagination_links_full @user_pages, @user_count %></p>
 
 <% html_title(l(:label_my_users)) -%>
-


### PR DESCRIPTION
In the User edit screen, list of available parents (Sponsor) now shows all active users as well as that User's parent, whether that parent is inactive or not.

Issue #1 
